### PR TITLE
Add CSS autoprefixer and minifier to build process

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,6 +8,18 @@ module.exports = function(grunt) {
 
         visuals: { },
 
+        postcss: {
+            options: {
+                processors: [
+                    require('autoprefixer')({browsers: ['> 5%', 'last 2 versions', 'IE 9', 'Safari 6']})
+                    require('cssnano')()
+                ]
+            },
+            dist: {
+                src: 'build/*.css'
+            }
+        },
+
         watch: {
             js: {
                 files: ['src/js/**/*'],
@@ -227,7 +239,7 @@ module.exports = function(grunt) {
 
     grunt.registerTask('embed', ['shell:embed', 'template:embed', 'sass:embed']);
     grunt.registerTask('interactive', ['shell:interactive', 'template:bootjs', 'sass:interactive']);
-    grunt.registerTask('all', ['interactive', 'embed', 'copy:assets'])
+    grunt.registerTask('all', ['interactive', 'embed', 'postcss', 'copy:assets'])
     grunt.registerTask('default', ['clean', 'copy:harness', 'all', 'connect', 'watch']);
     grunt.registerTask('build', ['clean', 'all']);
     grunt.registerTask('deploy', ['loadDeployConfig', 'prompt:visuals', 'build', 'copy:deploy', 'aws_s3', 'boot_url']);

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "1.0.0",
   "description": "Guardian Brexit Companion",
   "devDependencies": {
+    "autoprefixer": "^6.3.6",
     "bower": "^1.7.7",
+    "cssnano": "^3.5.2",
     "grunt": "^0.4.5",
     "grunt-aws-s3": "^0.13.0",
     "grunt-cli": "^1.1.0",
@@ -11,6 +13,7 @@
     "grunt-contrib-connect": "^0.10.1",
     "grunt-contrib-copy": "^0.8.0",
     "grunt-contrib-watch": "^0.6.1",
+    "grunt-postcss": "^0.8.0",
     "grunt-prompt": "^1.3.0",
     "grunt-sass": "^1.1.0",
     "grunt-shell": "^1.1.2",


### PR DESCRIPTION
The `autoprefixer` fixes the CSS rotation transforms on iOS 8. (Without the webkit prefix they were just ignored).

And `cssnano` halves the size of our css!

```
-rw-rw-rw-  1 joseph_smith  wheel  52052 17 May 12:51 embed.css
-rw-rw-rw-  1 joseph_smith  wheel  27893 17 May 15:35 embed.minified.css
```

@SiAdcock @annebyrne
