### PR TITLE
Fix source maps

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -69,7 +69,7 @@ module.exports = function(grunt) {
                 }
             },
             embed: {
-                command: './node_modules/.bin/jspm bundle-sfx <%= visuals.jspmFlags %> src/js/embed build/embed.js',
+                command: './node_modules/.bin/jspm bundle-sfx <%= visuals.jspmFlags %> src/js/embed build/embed.js --source-map-contents',
                 options: {
                     execOptions: {
                         cwd: '.'


### PR DESCRIPTION
Added `--source-map-contents` flag to `shell:embed` Grunt task. This inlines the minified source inside the source map itself.

Before:

``` json
{
    "version": 3,
    "sources": [
        "../jspm_packages/github/guardian/iframe-messenger@master/src/iframeMessenger.js",
        "../jspm_packages/github/guardian/iframe-messenger@master.js",
        "../jspm_packages/github/ded/reqwest@1.1.5/reqwest.js",
        "../jspm_packages/github/ded/reqwest@1.1.5.js",
        "../src/js/text/thankYou.html",
        "../src/js/text/questionAndAnswer.dot.html",
        "../src/js/text/expandableQuestionAndAnswer.dot.html",
        "../jspm_packages/github/olado/doT@1.0.1/doT.min.js",
        "../jspm_packages/github/olado/doT@1.0.1.js",
        "../src/js/embed.js"
    ],
    "names": [],
    "mappings": "...",
    "file": "embed.js"
}
```

After:

``` json
{
    "version": 3,
    "sources": [
        "../jspm_packages/github/guardian/iframe-messenger@master/src/iframeMessenger.js",
        "../jspm_packages/github/guardian/iframe-messenger@master.js",
        "../jspm_packages/github/ded/reqwest@1.1.5/reqwest.js",
        "../jspm_packages/github/ded/reqwest@1.1.5.js",
        "../src/js/text/thankYou.html",
        "../src/js/text/questionAndAnswer.dot.html",
        "../src/js/text/expandableQuestionAndAnswer.dot.html",
        "../jspm_packages/github/olado/doT@1.0.1/doT.min.js",
        "../jspm_packages/github/olado/doT@1.0.1.js",
        "../src/js/embed.js"
    ],
    "names": [],
    "mappings": "...",
    "file": "embed.js",
    "sourcesContent": [
        "minified JS content here"
    ]
}
```
