### PR TITLE
base64-encode inline svgs for Firefox

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -12,6 +12,10 @@ module.exports = function(grunt) {
             options: {
                 processors: [
                     require('autoprefixer')({browsers: ['> 5%', 'last 2 versions', 'IE 9', 'Safari 6']}),
+                    require('postcss-base64')({
+                      pattern: /<svg.*<\/svg>/i,
+                      prepend: 'data:image/svg+xml;base64,'
+                    }),
                     require('cssnano')()
                 ]
             },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "grunt-sass": "^1.1.0",
     "grunt-shell": "^1.1.2",
     "grunt-template": "^0.2.3",
-    "jit-grunt": "^0.9.1"
+    "jit-grunt": "^0.9.1",
+    "postcss-base64": "^0.4.1"
   },
   "scripts": {
     "start": "./node_modules/.bin/grunt",

--- a/src/css/embed.scss
+++ b/src/css/embed.scss
@@ -80,12 +80,12 @@ br {
     }
 
     &:before {
-        background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="250" height="18" viewBox="0 0 250 18"><path fill="#4BC6DF" d="M230 18l-1.6-18L22.7 18"/></svg>') no-repeat right;
+        background: url('<svg xmlns="http://www.w3.org/2000/svg" width="250" height="18" viewBox="0 0 250 18"><path fill="#4BC6DF" d="M230 18l-1.6-18L22.7 18"/></svg>') no-repeat right;
         top: -$shadow-height;
     }
 
     &:after {
-        background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="250" height="18" viewBox="0 0 250 18"><path fill="#4BC6DF" d="M20 0l1.6 18L227.3 0"/></svg>') no-repeat left;
+        background: url('<svg xmlns="http://www.w3.org/2000/svg" width="250" height="18" viewBox="0 0 250 18"><path fill="#4BC6DF" d="M20 0l1.6 18L227.3 0"/></svg>') no-repeat left;
         bottom: -$shadow-height;
     }
 }


### PR DESCRIPTION
This means our inline svgs display in Firefox!

Nicer long-term solution is to reference SVG assets but have their contents inlined as part of the build, which is what we do on, for instance, [Membership Frontend](https://github.com/guardian/membership-frontend)

@SiAdcock 
