### PR TITLE
Use min-height not height to ensure empty header takes up space

### DIFF
--- a/src/css/embed.scss
+++ b/src/css/embed.scss
@@ -95,7 +95,7 @@ br {
 
 .brexit__header {
     @include fs-header(3);
-    height: $baseline * 2;
+    min-height: $baseline * 2;
     padding-bottom: $baseline * 1.5;
 }
 .brexit__button {


### PR DESCRIPTION
I think you put the height on here so that empty headers still take space. But unfortunately it stops multi-line headers from taking up their correct amount of space!
#### before

![picture 224](https://cloud.githubusercontent.com/assets/5122968/15543247/0d929052-228c-11e6-8e6a-da4bf75c218e.png)
#### after

![picture 225](https://cloud.githubusercontent.com/assets/5122968/15543256/111fd1ee-228c-11e6-8ddf-233757f07075.png)

@SiAdcock 
