### PR TITLE
Integrate friendly tailoring

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+src/js/config.js

--- a/.eslintrc
+++ b/.eslintrc
@@ -18,7 +18,7 @@
         "indent": ["error", 4],
         "import/no-unresolved": [2,
             {
-                "ignore": ["!text$"]
+                "ignore": ["!text$", "!json$"]
             }
         ]
     }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,9 @@
   "jspm": {
     "configFile": "src/js/config.js",
     "dependencies": {
+      "async.parallel": "npm:async.parallel@^0.5.2",
       "guardian/iframe-messenger": "github:guardian/iframe-messenger@master",
+      "json": "github:systemjs/plugin-json@^0.1.2",
       "olado/doT": "github:olado/doT@^1.0.1",
       "reqwest": "github:ded/reqwest@^1.1.5",
       "text": "github:systemjs/plugin-text@^0.0.2"

--- a/src/config/application.json
+++ b/src/config/application.json
@@ -1,0 +1,4 @@
+{
+    "tailorUrl": "//members-data-api.thegulocal.com/tailor/me?tag=politics/eu-referendum",
+    "spreadsheetUrl": "//interactive.guim.co.uk/docsdata/1BtfoAr9B633r8mCJvrUtb838yRtyKuYHcYdUsmO2XGY.json"
+}

--- a/src/config/application.json
+++ b/src/config/application.json
@@ -1,4 +1,4 @@
 {
-    "tailorUrl": "//members-data-api.thegulocal.com/tailor/me?tag=politics/eu-referendum",
+    "tailorUrl": "https://members-data-api.theguardian.com/tailor/me?tag=politics/eu-referendum",
     "spreadsheetUrl": "//interactive.guim.co.uk/docsdata/1BtfoAr9B633r8mCJvrUtb838yRtyKuYHcYdUsmO2XGY.json"
 }

--- a/src/js/config.js
+++ b/src/js/config.js
@@ -1,24 +1,47 @@
 System.config({
-    baseURL: '/',
-    defaultJSExtensions: true,
-    transpiler: 'traceur',
-    paths: {
-        'github:*': 'jspm_packages/github/*',
-        'npm:*': 'jspm_packages/npm/*',
-    },
-    bundles: {
-        'build/main': [
-            'src/js/main',
-        ],
-    },
+  baseURL: "/",
+  defaultJSExtensions: true,
+  transpiler: "traceur",
+  paths: {
+    "github:*": "jspm_packages/github/*",
+    "npm:*": "jspm_packages/npm/*"
+  },
+  bundles: {
+    "build/main": [
+      "src/js/main"
+    ]
+  },
 
-    map: {
-        'guardian/iframe-messenger': 'github:guardian/iframe-messenger@master',
-        json: 'github:systemjs/plugin-json@0.1.0',
-        'olado/doT': 'github:olado/doT@1.0.1',
-        reqwest: 'github:ded/reqwest@1.1.5',
-        text: 'github:systemjs/plugin-text@0.0.2',
-        traceur: 'github:jmcriffey/bower-traceur@0.0.93',
-        'traceur-runtime': 'github:jmcriffey/bower-traceur-runtime@0.0.93',
+  map: {
+    "async.parallel": "npm:async.parallel@0.5.2",
+    "guardian/iframe-messenger": "github:guardian/iframe-messenger@master",
+    "json": "github:systemjs/plugin-json@0.1.2",
+    "olado/doT": "github:olado/doT@1.0.1",
+    "reqwest": "github:ded/reqwest@1.1.5",
+    "text": "github:systemjs/plugin-text@0.0.2",
+    "traceur": "github:jmcriffey/bower-traceur@0.0.93",
+    "traceur-runtime": "github:jmcriffey/bower-traceur-runtime@0.0.93",
+    "npm:async.eachof@0.5.2": {
+      "async.util.keyiterator": "npm:async.util.keyiterator@0.5.2",
+      "async.util.noop": "npm:async.util.noop@0.5.2",
+      "async.util.once": "npm:async.util.once@0.5.2",
+      "async.util.onlyonce": "npm:async.util.onlyonce@0.5.2"
     },
+    "npm:async.parallel@0.5.2": {
+      "async.eachof": "npm:async.eachof@0.5.2",
+      "async.util.parallel": "npm:async.util.parallel@0.5.2"
+    },
+    "npm:async.util.isarraylike@0.5.2": {
+      "async.util.isarray": "npm:async.util.isarray@0.5.2"
+    },
+    "npm:async.util.keyiterator@0.5.2": {
+      "async.util.isarraylike": "npm:async.util.isarraylike@0.5.2",
+      "async.util.keys": "npm:async.util.keys@0.5.2"
+    },
+    "npm:async.util.parallel@0.5.2": {
+      "async.util.isarraylike": "npm:async.util.isarraylike@0.5.2",
+      "async.util.noop": "npm:async.util.noop@0.5.2",
+      "async.util.restparam": "npm:async.util.restparam@0.5.2"
+    }
+  }
 });

--- a/src/js/formats/bigNumberCarousel.js
+++ b/src/js/formats/bigNumberCarousel.js
@@ -10,16 +10,16 @@ export default {
         const max = 5;
         let i = 1;
         let bigNumber;
-        let answer;
+        let content;
 
         for (; i <= max; i += 1) {
-            bigNumber = data[`number_${i}`];
-            answer = data[`fact_${i}`];
-            if (answer && bigNumber) {
+            bigNumber = data[`headline${i}`];
+            content = data[`content${i}`];
+            if (content && bigNumber) {
                 bigNumber = bigNumber.replace(
                     bigNumberMatcher, '<span class="big-number">$1</span>'
                 );
-                slides.push({ bigNumber, answer });
+                slides.push({ bigNumber, content });
             }
         }
         newData.slides = slides;
@@ -32,5 +32,4 @@ export default {
         buildCarousel(slideCount);
     },
     template: carouselTemplate,
-    url: 'https://interactive.guim.co.uk/docsdata/1h7mnJsLETpkgNe2UJC35ChJzrHVi7INjLpH5sEAYcqQ.json',
 };

--- a/src/js/formats/expandable.js
+++ b/src/js/formats/expandable.js
@@ -2,23 +2,23 @@ import q from '../lib/query';
 import expandableTemplate from '../text/expandable.dot.html!text';
 
 export default {
-    preprocess(data) {
-        // TODO: don't modify data in place!
-        const words = data.Answer.split(' ');
+    preprocess({ content1: content, headline1: header, survey_like, survey_dislike }) {
+        const words = content.split(' ');
+        const mainContentLength = 65;
+        const mainContent = words.slice(0, mainContentLength).join(' ');
+        const extraContent = words.slice(mainContentLength).join(' ');
 
-        data.mainAnswer = words.slice(0, 65).join(' ');
-        data.extraAnswer = words.slice(65).join(' ');
-
-        return data;
+        return { header, mainContent, extraContent, survey_like, survey_dislike };
     },
     postRender() {
         q('.js-expand').forEach(el => el.addEventListener('click', ev => {
             const readMoreLink = ev.currentTarget;
 
-            q('.js-extra-content').forEach(extraContentElement => extraContentElement.classList.remove('u-hidden'));
+            q('.js-extra-content').forEach(extraContentElement => {
+                extraContentElement.classList.remove('u-hidden');
+            });
             readMoreLink.remove();
         }));
     },
     template: expandableTemplate,
-    url: 'https://interactive.guim.co.uk/docsdata/1zsqQf4mq8fsAkZAXnoSCNpap2hykFDA3Cm3HaI9qe8k.json',
 };

--- a/src/js/formats/flat.js
+++ b/src/js/formats/flat.js
@@ -1,12 +1,9 @@
 import flatTemplate from '../text/flat.dot.html!text';
 
 export default {
-    preprocess(data) {
-        return data;
+    preprocess({ headline1: header, content1: content, survey_like, survey_dislike }) {
+        return { header, content, survey_like, survey_dislike };
     },
-    postRender() {
-
-    },
+    postRender() {},
     template: flatTemplate,
-    url: 'https://interactive.guim.co.uk/docsdata/1zsqQf4mq8fsAkZAXnoSCNpap2hykFDA3Cm3HaI9qe8k.json',
 };

--- a/src/js/formats/index.js
+++ b/src/js/formats/index.js
@@ -9,5 +9,5 @@ export default {
     expandable,
     number_carousel: bigNumberCarousel,
     text_carousel: textCarousel,
-    two_sided: twoSided
+    two_sided: twoSided,
 };

--- a/src/js/formats/textCarousel.js
+++ b/src/js/formats/textCarousel.js
@@ -8,14 +8,14 @@ export default {
         const newData = { survey_like, survey_dislike };
         const max = 5;
         let i = 1;
-        let headline;
-        let answer;
+        let header;
+        let content;
 
         for (; i <= max; i += 1) {
-            headline = data[`answer_${i}_title`];
-            answer = data[`answer_${i}_body`];
-            if (typeof headline !== 'undefined' && typeof answer !== 'undefined') {
-                slides.push({ headline, answer });
+            header = data[`headline${i}`];
+            content = data[`content${i}`];
+            if (typeof header !== 'undefined' && typeof content !== 'undefined') {
+                slides.push({ header, content });
             }
         }
         newData.slides = slides;
@@ -28,5 +28,4 @@ export default {
         buildCarousel(slideCount);
     },
     template: carouselTemplate,
-    url: 'https://interactive.guim.co.uk/docsdata/1pLLboA0_VJEDvXD5kuERWaQMdevH0DuiOrpESnCbkXQ.json',
 };

--- a/src/js/formats/twoSided.js
+++ b/src/js/formats/twoSided.js
@@ -3,14 +3,33 @@ import q from '../lib/query';
 import slider from './helpers/slider';
 
 export default {
-    preprocess(data) {
-        return data;
+    preprocess({
+        headline1: question,
+        headline2: answer_1_title,
+        content2: answer_1_body,
+        headline3: answer_2_title,
+        content3: answer_2_body,
+        survey_like,
+        survey_dislike,
+    }) {
+        return {
+            question,
+            answer_1_title,
+            answer_1_body,
+            answer_2_title,
+            answer_2_body,
+            survey_like,
+            survey_dislike,
+        };
     },
-    postRender(data) {
+    postRender() {
         function goToAnswer(answer) {
-            q(`.js-back-to-question[data-answer="${answer}"]`).forEach(el => el.classList.remove('u-hidden'));
-            q('.js-go-to-answer').forEach(el => el.classList.add('u-hidden'));
-
+            q(`.js-back-to-question[data-answer="${answer}"]`).forEach(el => {
+                el.classList.remove('u-hidden');
+            });
+            q('.js-go-to-answer').forEach(el => {
+                el.classList.add('u-hidden');
+            });
             if (answer === 'one') {
                 slider.slideLeft();
             } else {
@@ -20,22 +39,16 @@ export default {
 
         function backToQuestion() {
             slider.reset();
-
             q('.js-back-to-question').forEach(el => el.classList.add('u-hidden'));
-
             q('.js-go-to-answer').forEach(el => el.classList.remove('u-hidden'));
         }
 
         q('.js-go-to-answer').forEach(el => {
-            el.addEventListener('click', ev => goToAnswer(el.getAttribute('data-answer')));
+            el.addEventListener('click', () => goToAnswer(el.getAttribute('data-answer')));
         });
-
         q('.js-back-to-question').forEach(el => {
-            el.addEventListener('click', ev => backToQuestion());
+            el.addEventListener('click', () => backToQuestion());
         });
     },
     template: twoSidedTemplate,
-
-    url: 'https://interactive.guim.co.uk/docsdata/1SYM89nttwfXXMHJu-ACBbZxo03Vh5zGGDp7kpc8JX2Q.json',
-
 };

--- a/src/js/requests.js
+++ b/src/js/requests.js
@@ -1,0 +1,42 @@
+import config from '../config/application.json!json';
+import reqwest from 'reqwest';
+
+export default {
+    spreadsheetRequest(callback) {
+        reqwest({
+            url: config.spreadsheetUrl,
+            type: 'json',
+            crossOrigin: false,
+            error(err) {
+                callback(err);
+            },
+            success(res) {
+                callback(null, res);
+            },
+        });
+    },
+    tailorRequest(callback) {
+        reqwest({
+            url: config.tailorUrl,
+            type: 'json',
+            crossOrigin: true,
+            withCredentials: true,
+            error() {
+                callback(null, {});
+            },
+            success(res) {
+                const count = res.viewedTags['politics/eu-referendum'];
+                let level;
+
+                if (count < 5) {
+                    level = 'beginner';
+                } else if (count > 9) {
+                    level = 'advanced';
+                } else {
+                    level = 'intermediate';
+                }
+                callback(null, { level });
+            },
+        });
+    },
+};

--- a/src/js/text/carousel.dot.html
+++ b/src/js/text/carousel.dot.html
@@ -2,9 +2,9 @@
     <ol class="brexit__content">
         {{~it.data.slides :value:index}}
         <li class="brexit__carousel-slide{{? index===0}} brexit__carousel-slide--current js-current{{?}}" id="carousel-slide-{{=index}}">
-            {{? typeof value.headline !== 'undefined'}}
+            {{? typeof value.header !== 'undefined'}}
             <h1 class="brexit__header">
-                {{=value.headline}}
+                {{=value.header}}
             </h1>
             {{?? value.bigNumber}}
             <p class="brexit__carousel-header">
@@ -12,7 +12,7 @@
             </p>
             {{?}}
             <p class="brexit__carousel-text">
-                {{=value.answer}}
+                {{=value.content}}
             </p>
         </li>
         {{~}}

--- a/src/js/text/expandable.dot.html
+++ b/src/js/text/expandable.dot.html
@@ -1,12 +1,12 @@
 <div class="brexit">
     <h1 class="brexit__header">
-        {{=it.data.Question}}
+        {{=it.data.header}}
     </h1>
     <p>
-        {{=it.data.mainAnswer}}
+        {{=it.data.mainContent}}
         <a class="js-expand brexit__read-more" data-link-name="{{=it.trackingCode.more}}" href="#">Show more...</a>
         <span class="js-extra-content u-hidden">
-            {{=it.data.extraAnswer}}
+            {{=it.data.extraContent}}
         </span>
     </p>
     <div class="js-extra-content u-hidden brexit__feedback">

--- a/src/js/text/flat.dot.html
+++ b/src/js/text/flat.dot.html
@@ -1,9 +1,9 @@
 <div class="brexit">
     <h1 class="brexit__header">
-        {{=it.data.Question}}
+        {{=it.data.header}}
     </h1>
     <p>
-        {{=it.data.Answer}}
+        {{=it.data.content}}
     </p>
     <div class="brexit__feedback">
         {{#def.feedback}}


### PR DESCRIPTION
Lots of things:
- Refactored old params, removing `format` and `sheet`
- All atom content is now consolidated into one sheet. Removed JSON URLs from individual atom formats
- Extracted API URIs into `application.json` config file
- Incorporated new tailored param structure (`embed.html?tailored=true&beginner=atomid1&intermediate=atomid2&advanced=atomid3&default=beginner`)
- Implemented tailoring algorithm (count < 5 is beginner, < 9 intermediate, >= 9 advanced )

@joelochlann 
