### PR TITLE
Use generic 'go to' tracking code and concatenate in the template

### DIFF
--- a/src/js/embed.js
+++ b/src/js/embed.js
@@ -93,8 +93,7 @@ window.init = function init(parentEl) {
                 more: `${trackingCode}__more`,
                 prev: `${trackingCode}__prev`,
                 next: `${trackingCode}__next`,
-                goToAnswerOne: `${trackingCode}__go_to_answer_one`,
-                goToAnswerTwo: `${trackingCode}__go_to_answer_two`,
+                goTo: `${trackingCode}__go_to`,
                 back: `${trackingCode}__back`,
             },
         };

--- a/src/js/text/carousel.dot.html
+++ b/src/js/text/carousel.dot.html
@@ -25,7 +25,7 @@
     </a>
     <div class="brexit__carousel-indicators">
         {{~it.data.slides :value:index}}
-        <a id="carousel-indicator-{{=index}}" class="brexit__carousel-indicator--hit js-indicator" data-link-name="{{=it.trackingCode}}__slide_{{=index}}">
+        <a id="carousel-indicator-{{=index}}" class="brexit__carousel-indicator--hit js-indicator" data-link-name="{{=it.trackingCode.goTo}}_slide_{{=index}}">
             <div class="brexit__carousel-indicator{{? index===0}} brexit__carousel-indicator--active js-active{{??}} brexit__carousel-indicator--passive{{?}}"></div>
         </a>
         {{~}}

--- a/src/js/text/twoSided.dot.html
+++ b/src/js/text/twoSided.dot.html
@@ -15,7 +15,7 @@
             <div class="brexit__content brexit__slider__item brexit__two-sided">
                 <div class="brexit__two-sided__row brexit__two-sided__top">
                     <a data-answer="one"
-                       data-link-name="{{=it.trackingCode.goToAnswerOne}}"
+                       data-link-name="{{=it.trackingCode.goTo}}_answer_one"
                        class="brexit__two-sided__control brexit__two-sided__control--left js-go-to-answer">
                         <div class="brexit__two-sided__button brexit__two-sided__button--prev">
                             {{=it.data.answer_1_title}}
@@ -29,7 +29,7 @@
                 </div>
                 <div class="brexit__two-sided__row brexit__two-sided__bottom">
                     <a data-answer="two"
-                       data-link-name="{{=it.trackingCode.goToAnswerTwo}}"
+                       data-link-name="{{=it.trackingCode.goTo}}_answer_two"
                        class="brexit__two-sided__control brexit__two-sided__control--right js-go-to-answer">
                         <div class="brexit__two-sided__button brexit__two-sided__button--next">
                             {{=it.data.answer_2_title}}

--- a/src/js/text/twoSided.dot.html
+++ b/src/js/text/twoSided.dot.html
@@ -51,10 +51,10 @@
         </div>
     </div>
 
-    <a data-answer="two" data-link-name="{{=it.trackingCode.back}}" class="brexit__nav-control brexit__nav-control--prev js-back-to-question u-hidden">
+    <a data-answer="two" data-link-name="{{=it.trackingCode.back}}_from_answer_two" class="brexit__nav-control brexit__nav-control--prev js-back-to-question u-hidden">
         <div class="brexit__nav-control__label"></div>
     </a>
-    <a data-answer="one" data-link-name="{{=it.trackingCode.back}}" class="brexit__nav-control brexit__nav-control--next js-back-to-question u-hidden">
+    <a data-answer="one" data-link-name="{{=it.trackingCode.back}}_from_answer_one" class="brexit__nav-control brexit__nav-control--next js-back-to-question u-hidden">
         <div class="brexit__nav-control__label"></div>
     </a>
 </div>


### PR DESCRIPTION
#29 had a mistake [here](https://github.com/guardian/interactive-brexit-companion/blob/b4302b39b992548f6eeae406cfedfc938f958b69/src/js/text/carousel.dot.html#L28) - it used `trackingCode` which is an object, rather than one of its string properties.

@SiAdcock 
