### PR TITLE
Understand and tolerate `tailored=false` requests

### DIFF
--- a/src/js/embed.js
+++ b/src/js/embed.js
@@ -63,9 +63,9 @@ function getQueryParams() {
 
 window.init = function init(parentEl) {
     const params = getQueryParams();
-    const isTailored = (params.tailored == 'true');
+    const isTailored = (params.tailored === 'true');
     const defaultLevel = params.default || 'intermediate';
-    const defaultAtomId = params[defaultLevel] || params.id
+    const defaultAtomId = params[defaultLevel] || params.id;
 
     iframeMessenger.enableAutoResize();
     setupVisibilityMonitoring();

--- a/src/js/embed.js
+++ b/src/js/embed.js
@@ -63,7 +63,9 @@ function getQueryParams() {
 
 window.init = function init(parentEl) {
     const params = getQueryParams();
-    const isTailored = !!params.tailored;
+    const isTailored = (params.tailored == 'true');
+    const defaultLevel = params.default || 'intermediate';
+    const defaultAtomId = params[defaultLevel] || params.id
 
     iframeMessenger.enableAutoResize();
     setupVisibilityMonitoring();
@@ -135,7 +137,7 @@ window.init = function init(parentEl) {
             throw err;
         }
         const rows = getRows(spreadsheetRes);
-        const level = tailorRes.level || params.default;
+        const level = tailorRes.level || defaultLevel;
         const id = params[level];
         const row = getRowById(rows, id);
         const trackingCode = `brexit__${level}__${id}__tailored`;
@@ -148,7 +150,7 @@ window.init = function init(parentEl) {
             throw err;
         }
         const rows = getRows(spreadsheetRes);
-        const id = params.id;
+        const id = defaultAtomId;
         const row = getRowById(rows, id);
         const trackingCode = `brexit__${row.level}__${id}__untailored`;
 


### PR DESCRIPTION
Part of the changes aim to tolerate `tailored=false`, like in this url:

https://interactive.guim.co.uk/2016/05/brexit-companion/embed/embed.html?tailored=false&beginner=who_can_vote&intermediate=impact_economy&advanced=can_overrule_vote&default=beginner

...which can be produced by https://github.com/guardian/frontend/pull/13157, which sets `tailored=true` to `tailored=false` for 50% of users.

The `id` value can still be used to set an atomId, but if tailored params are present (ie `default`, `beginner`, `intermediate`, etc) they will override the `id` value, even if `tailored=false` or is not even set.

cc @SiAdcock @joelochlann 
