### PR TITLE
Expandable content splitting

### DIFF
--- a/src/css/embed.scss
+++ b/src/css/embed.scss
@@ -114,6 +114,11 @@ $brexit-control-button-size: 28px;
     min-height: $baseline * 2;
     padding-bottom: $baseline * 1.5;
 }
+.brexit__content {
+    @include fs-textSans(3);
+    margin: 0 0 $baseline/2 0;
+    font-weight: bold;
+}
 .brexit__button {
     height: 28px;
     width: 28px;

--- a/src/js/embed.js
+++ b/src/js/embed.js
@@ -93,6 +93,7 @@ window.init = function init(parentEl) {
                 like: `${trackingCode}__like`,
                 dislike: `${trackingCode}__dislike`,
                 more: `${trackingCode}__more`,
+                less: `${trackingCode}__less`,
                 prev: `${trackingCode}__prev`,
                 next: `${trackingCode}__next`,
                 goTo: `${trackingCode}__go_to`,

--- a/src/js/formats/expandable.js
+++ b/src/js/formats/expandable.js
@@ -4,17 +4,25 @@ import expandableTemplate from '../text/expandable.dot.html!text';
 export default {
     preprocess({ content1: content, headline1: header, survey_like, survey_dislike }) {
         const words = content.split(' ');
-        const mainContentLength = 65;
-        const mainContent = words.slice(0, mainContentLength).join(' ');
-        const extraContent = words.slice(mainContentLength).join(' ');
+        const shortContentLength = 65;
+        const shortContent = words.slice(0, shortContentLength).join(' ');
 
-        return { header, mainContent, extraContent, survey_like, survey_dislike };
+        return {
+            header,
+            shortContent,
+            survey_like,
+            survey_dislike,
+            allContent: content,
+        };
     },
     postRender() {
         q('.js-expand').forEach(el => el.addEventListener('click', ev => {
             const readMoreLink = ev.currentTarget;
 
-            q('.js-extra-content').forEach(extraContentElement => {
+            q('.js-short-content').forEach(extraContentElement => {
+                extraContentElement.classList.add('u-hidden');
+            });
+            q('.js-all-content').forEach(extraContentElement => {
                 extraContentElement.classList.remove('u-hidden');
             });
             readMoreLink.remove();

--- a/src/js/formats/expandable.js
+++ b/src/js/formats/expandable.js
@@ -16,16 +16,21 @@ export default {
         };
     },
     postRender() {
-        q('.js-expand').forEach(el => el.addEventListener('click', ev => {
-            const readMoreLink = ev.currentTarget;
-
-            q('.js-short-content').forEach(extraContentElement => {
-                extraContentElement.classList.add('u-hidden');
+        q('.js-expand').forEach(el => el.addEventListener('click', () => {
+            q('.js-short-content').forEach(shortContentElement => {
+                shortContentElement.classList.add('u-hidden');
             });
-            q('.js-all-content').forEach(extraContentElement => {
-                extraContentElement.classList.remove('u-hidden');
+            q('.js-all-content').forEach(allContentElement => {
+                allContentElement.classList.remove('u-hidden');
             });
-            readMoreLink.remove();
+        }));
+        q('.js-collapse').forEach(el => el.addEventListener('click', () => {
+            q('.js-all-content').forEach(allContentElement => {
+                allContentElement.classList.add('u-hidden');
+            });
+            q('.js-short-content').forEach(shortContentElement => {
+                shortContentElement.classList.remove('u-hidden');
+            });
         }));
     },
     template: expandableTemplate,

--- a/src/js/text/expandable.dot.html
+++ b/src/js/text/expandable.dot.html
@@ -2,14 +2,14 @@
     <h1 class="brexit__header">
         {{=it.data.header}}
     </h1>
-    <p>
-        {{=it.data.mainContent}}
+    <div class="js-short-content brexit__content">
+        {{=it.data.shortContent}}
         <a class="js-expand brexit__read-more" data-link-name="{{=it.trackingCode.more}}" href="#">Show more...</a>
-        <span class="js-extra-content u-hidden">
-            {{=it.data.extraContent}}
-        </span>
-    </p>
-    <div class="js-extra-content u-hidden brexit__feedback">
+    </div>
+    <div class="js-all-content brexit__content u-hidden">
+        {{=it.data.allContent}}
+    </div>
+    <div class="js-all-content u-hidden brexit__feedback">
         {{#def.feedback}}
     </div>
 </div>

--- a/src/js/text/expandable.dot.html
+++ b/src/js/text/expandable.dot.html
@@ -4,10 +4,11 @@
     </h1>
     <div class="js-short-content brexit__content">
         {{=it.data.shortContent}}
-        <a class="js-expand brexit__read-more" data-link-name="{{=it.trackingCode.more}}" href="#">Show more...</a>
+        <a class="js-expand brexit__read-more" data-link-name="{{=it.trackingCode.more}}" href="#">... Show more</a>
     </div>
     <div class="js-all-content brexit__content u-hidden">
         {{=it.data.allContent}}
+        <a class="js-collapse brexit__read-more" data-link-name="{{=it.trackingCode.less}}" href="#">Show less</a>
     </div>
     <div class="js-all-content u-hidden brexit__feedback">
         {{#def.feedback}}


### PR DESCRIPTION
Currently, copy for expandable atoms is split at 65 words. Initially, the first 65 words are shown and if the user clicks "Show more..." the remainder of the words are shown.

This change shows the first 65 words initially in its own `div`. If the user clicks "Show more...", this `div` is hidden and another `div` containing all the content is shown. If the user clicks "Show less", the `div` containing all content is hidden and the `div` containing the first 65 words is shown.

![picture 13](https://cloud.githubusercontent.com/assets/5931528/15772849/7e86ade4-296b-11e6-9db4-6c7006dc1f0d.png)

The purpose of this PR is to better support HTML embedded in copy in the gudocs spreadsheet.
## Known limitations
1. If the content is split midway through an element (e.g. if word 64 is `<a` and word 65 is `href="http://example.com">`), the tag is never closed and the behaviour becomes unpredictable. In the future we could support a basic markdown-like syntax to avoid HTML injection altogether.
2. If content in the spreadsheet is wrapped in a block element (e.g. `<ul> ... </ul>`), the "Show less" link will not appear inline with the content, and will appear below the content.

![picture 14](https://cloud.githubusercontent.com/assets/5931528/15772903/d43ceba4-296b-11e6-9104-f21de3a365c0.png)
