### PR TITLE
Enable CI builds

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -232,6 +232,7 @@ module.exports = function(grunt) {
     grunt.registerTask('all', ['embed', 'postcss', 'copy:assets']);
     grunt.registerTask('default', ['clean', 'copy:harness', 'all', 'connect', 'watch']);
     grunt.registerTask('build', ['clean', 'all']);
+    grunt.registerTask('package', ['loadDeployConfig', 'build', 'copy:deploy']);
     grunt.registerTask('deploy', ['loadDeployConfig', 'prompt:visuals', 'build', 'copy:deploy', 'aws_s3', 'boot_url']);
 
     grunt.loadNpmTasks('grunt-aws');

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -216,7 +216,7 @@ module.exports = function(grunt) {
             s3: grunt.file.readJSON('./cfg/s3.json'),
             timestamp: Date.now(),
             jspmFlags: '-m',
-            assetPath: '<%= visuals.s3.domain %><%= visuals.s3.path %>/<%= visuals.timestamp %>'
+            assetPath: '<%= visuals.timestamp %>'
         });
     })
 

--- a/src/embed.html
+++ b/src/embed.html
@@ -3,13 +3,13 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="stylesheet" type="text/css" href="<%= assetPath %>/embed.css" />
+    <link rel="stylesheet" type="text/css" href="../<%= assetPath %>/embed.css" />
 </head>
 <body>
     <div class="interactive-embed js-interactive"></div>
-    <script src="<%= assetPath %>/embed.js"></script>
+    <script src="../<%= assetPath %>/embed.js"></script>
     <script>
-        init(document.querySelector('.js-interactive'), {'assetPath': '<%= assetPath %>'});
+        init(document.querySelector('.js-interactive'), {});
     </script>
     <script src="//j.ophan.co.uk/interactive.js"></script>
 </body>


### PR DESCRIPTION
This is preparation for getting Riff Raff to deploy the interactive. These first steps:
- Remove hard-coding of the deployment path in the artifact (RiffRaff depeneds on artifacts being identical, no matter what stage they're deployed to)
- Give a single `package` task - https://github.com/jonnyzzz/TeamCity.Node failed to parse multiline tasks anyway.

The new CI task is at: https://teamcity-aws.gutools.co.uk/viewType.html?buildTypeId=memsub_membership_InteractiveBrexitCompanion

Once this is merged, I'll enable feedback from teamCity to the GitHub PRs, so we can see if PRs pass the build process.

cc @annebyrne @joelochlann @SiAdcock 
