### PR TITLE
Support markdown links across all atom formats

### DIFF
--- a/src/js/formats/bigNumberCarousel.js
+++ b/src/js/formats/bigNumberCarousel.js
@@ -1,6 +1,7 @@
 import carouselTemplate from '../text/carousel.dot.html!text';
 import buildCarousel from './helpers/buildCarousel';
 import { maxCarouselSize } from '../../config/application.json!json';
+import markdown from '../lib/markdown';
 
 export default {
     preprocess(data) {
@@ -14,7 +15,7 @@ export default {
 
         for (; i <= maxCarouselSize; i += 1) {
             bigNumber = data[`headline${i}`];
-            content = data[`content${i}`];
+            content = markdown.getHtmlContentString(data[`content${i}`]);
             if (content && bigNumber) {
                 bigNumber = bigNumber.replace(
                     bigNumberMatcher, '<span class="big-number">$1</span>'

--- a/src/js/formats/expandable.js
+++ b/src/js/formats/expandable.js
@@ -1,18 +1,20 @@
 import q from '../lib/query';
+import markdown from '../lib/markdown';
 import expandableTemplate from '../text/expandable.dot.html!text';
 
 export default {
     preprocess({ content1: content, headline1: header, survey_like, survey_dislike }) {
-        const words = content.split(' ');
         const shortContentLength = 65;
-        const shortContent = words.slice(0, shortContentLength).join(' ');
+        const htmlContentArray = markdown.getHtmlContentArray(content);
+        const shortContent = htmlContentArray.slice(0, shortContentLength).join(' ');
+        const allContent = htmlContentArray.join(' ');
 
         return {
             header,
             shortContent,
             survey_like,
             survey_dislike,
-            allContent: content,
+            allContent,
         };
     },
     postRender() {

--- a/src/js/formats/flat.js
+++ b/src/js/formats/flat.js
@@ -1,9 +1,18 @@
 import flatTemplate from '../text/flat.dot.html!text';
+import markdown from '../lib/markdown';
 
 export default {
-    preprocess({ headline1: header, content1: content, survey_like, survey_dislike }) {
-        return { header, content, survey_like, survey_dislike };
+    preprocess({ headline1: header, content1, survey_like, survey_dislike }) {
+        const content = markdown.getHtmlContentString(content1);
+
+        return {
+            header,
+            content,
+            survey_like,
+            survey_dislike,
+        };
     },
-    postRender() {},
+    postRender() {
+    },
     template: flatTemplate,
 };

--- a/src/js/formats/textCarousel.js
+++ b/src/js/formats/textCarousel.js
@@ -1,6 +1,7 @@
 import carouselTemplate from '../text/carousel.dot.html!text';
 import buildCarousel from './helpers/buildCarousel';
 import { maxCarouselSize } from '../../config/application.json!json';
+import markdown from '../lib/markdown';
 
 export default {
     preprocess(data) {
@@ -13,7 +14,7 @@ export default {
 
         for (; i <= maxCarouselSize; i += 1) {
             header = data[`headline${i}`];
-            content = data[`content${i}`];
+            content = markdown.getHtmlContentString(data[`content${i}`]);
             if (header || content) {
                 slides.push({ header, content });
             }

--- a/src/js/formats/twoSided.js
+++ b/src/js/formats/twoSided.js
@@ -1,23 +1,27 @@
 import twoSidedTemplate from '../text/twoSided.dot.html!text';
 import q from '../lib/query';
 import slider from './helpers/slider';
+import markdown from '../lib/markdown';
 
 export default {
     preprocess({
         headline1: question,
-        headline2: answer_1_title,
-        content2: answer_1_body,
-        headline3: answer_2_title,
-        content3: answer_2_body,
+        headline2: answer1Title,
+        headline3: answer2Title,
+        content2,
+        content3,
         survey_like,
         survey_dislike,
     }) {
+        const answer1Body = markdown.getHtmlContentString(content2);
+        const answer2Body = markdown.getHtmlContentString(content3);
+
         return {
             question,
-            answer_1_title,
-            answer_1_body,
-            answer_2_title,
-            answer_2_body,
+            answer1Title,
+            answer1Body,
+            answer2Title,
+            answer2Body,
             survey_like,
             survey_dislike,
         };

--- a/src/js/lib/markdown.js
+++ b/src/js/lib/markdown.js
@@ -1,0 +1,57 @@
+function findMarkdownLinks(content) {
+    const anchorRegexp = /\[(.+?)\]\((.+?)\)/g;
+    const matches = [];
+    let next = anchorRegexp.exec(content);
+
+    while (next) {
+        matches.push(next);
+        next = anchorRegexp.exec(content);
+    }
+
+    return matches;
+}
+
+function replaceMarkdownLinksWithTokens(prev, link, index) {
+    return prev.replace(link[0], `%LINK_${index}%`);
+}
+
+function replaceTokensWithLinks(tokenisedWords, markdownLinks) {
+    return tokenisedWords.map((word) => {
+        const tokenRegexp = /%LINK_(\d)%/;
+        let tokenIndex;
+        let anchorHref;
+        let anchorText;
+
+        if (word.match(tokenRegexp)) {
+            tokenIndex = tokenRegexp.exec(word)[1];
+            [, anchorHref, anchorText] = markdownLinks[tokenIndex];
+            return `<a href="${anchorHref}" target="_blank">${anchorText}</a>`;
+        }
+
+        return word;
+    });
+}
+
+function getHtmlContentArray(content) {
+    const markdownLinks = findMarkdownLinks(content);
+
+    if (!markdownLinks.length) {
+        return content.split(' ');
+    }
+
+    const tokenisedContent = markdownLinks.reduce(replaceMarkdownLinksWithTokens, content);
+    const tokenisedWords = tokenisedContent.split(' ');
+
+    return replaceTokensWithLinks(tokenisedWords, markdownLinks);
+}
+
+function getHtmlContentString(content) {
+    const htmlContentArray = getHtmlContentArray(content);
+
+    return htmlContentArray.join(' ');
+}
+
+export default {
+    getHtmlContentArray,
+    getHtmlContentString,
+};

--- a/src/js/text/twoSided.dot.html
+++ b/src/js/text/twoSided.dot.html
@@ -3,10 +3,10 @@
         <div class="brexit__slider js-slider">
             <div class="brexit__content brexit__slider__item">
                 <h1 class="brexit__header">
-                    {{=it.data.answer_1_title}}
+                    {{=it.data.answer1Title}}
                 </h1>
                 <p>
-                    {{=it.data.answer_1_body}}
+                    {{=it.data.answer1Body}}
                 </p>
                 <div class="brexit__feedback">
                     {{#def.feedback}}
@@ -18,7 +18,7 @@
                        data-link-name="{{=it.trackingCode.goTo}}_answer_one"
                        class="brexit__two-sided__control brexit__two-sided__control--left js-go-to-answer">
                         <div class="brexit__two-sided__button brexit__two-sided__button--prev">
-                            {{=it.data.answer_1_title}}
+                            {{=it.data.answer1Title}}
                         </div>
                     </a>
                 </div>
@@ -32,17 +32,17 @@
                        data-link-name="{{=it.trackingCode.goTo}}_answer_two"
                        class="brexit__two-sided__control brexit__two-sided__control--right js-go-to-answer">
                         <div class="brexit__two-sided__button brexit__two-sided__button--next">
-                            {{=it.data.answer_2_title}}
+                            {{=it.data.answer2Title}}
                         </div>
                     </a>
                 </div>
             </div>
             <div class="brexit__content brexit__slider__item">
                 <h1 class="brexit__header">
-                    {{=it.data.answer_2_title}}
+                    {{=it.data.answer2Title}}
                 </h1>
                 <p>
-                    {{=it.data.answer_2_body}}
+                    {{=it.data.answer2Body}}
                 </p>
                 <div class="brexit__feedback">
                     {{#def.feedback}}


### PR DESCRIPTION
Links could previously be embedded into content atoms using standard HTML syntax (`<a href="http://www.example.com">Hello</a>`). This is less than ideal for 3 reasons:
1. Not everyone knows HTML. It would be easier to support a simpler syntax that everyone can pick up quickly.
2. Expandable atoms cut content after 65 words. This can cause HTML to break mid-tag, leading to unpredictable errors
3. Injecting unchecked HTML into our atoms is a recipe for XSS vulnerabilities

This fix allows content editors to use the markdown syntax to add links to their atoms (`[http://www.example.com](Hello)`). The content is tokenised and then HTML is safely constructed on the client.

If this goes well, we can create separate PRs to handle other forms of markdown support, and then remove support of HTML injection altogether.

@joelochlann 
