### PR TITLE
Install pre-commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "grunt-shell": "^1.1.2",
     "grunt-template": "^0.2.3",
     "jit-grunt": "^0.9.1",
-    "postcss-base64": "^0.4.1"
+    "postcss-base64": "^0.4.1",
+    "pre-commit": "^1.1.3"
   },
   "scripts": {
     "start": "./node_modules/.bin/grunt",
@@ -31,6 +32,9 @@
     "lint": "./node_modules/.bin/eslint ./src/js",
     "postinstall": "./node_modules/.bin/bower install && ./node_modules/.bin/jspm install"
   },
+  "pre-commit": [
+    "lint"
+  ],
   "author": "",
   "license": "ISC",
   "jspm": {


### PR DESCRIPTION
Pre-commit hooks will help us maintain code quality by running static analysis checks.

For now, this just runs the lint task and prevents the commit if linting fails.
