### PR TITLE
Reinstate user agent padding on lists, remove padding from carousel lists

### DIFF
--- a/src/css/embed.scss
+++ b/src/css/embed.scss
@@ -60,7 +60,6 @@ p, ol, ul {
     @include fs-textSans(3);
     margin: 0 0 $baseline/2 0;
     font-weight: bold;
-    padding: 0;
 }
 ul {
     padding-left: $gutter * 2;

--- a/src/css/modules/_carousel.scss
+++ b/src/css/modules/_carousel.scss
@@ -1,5 +1,6 @@
 .explainer__carousel {
     list-style: none;
+    padding: 0;
 }
 
 .explainer__carousel-indicators {


### PR DESCRIPTION
List padding broken in the slider refactor:

![picture 22](https://cloud.githubusercontent.com/assets/5931528/16146358/80af0fb6-3475-11e6-834e-f26e84432d2a.png)

Fixed it:

![picture 21](https://cloud.githubusercontent.com/assets/5931528/16146368/88cd16c0-3475-11e6-98e7-5959a29efadb.png)

@joelochlann 
