### PR TITLE
Remove unnecessary href attr from 'show more/less' links

### DIFF
--- a/src/js/text/expandable.dot.html
+++ b/src/js/text/expandable.dot.html
@@ -4,11 +4,11 @@
     </h1>
     <div class="js-short-content explainer__content">
         {{=it.data.shortContent}}
-        <a class="js-expand explainer__read-more" data-link-name="{{=it.trackingCode.more}}" href="#">... Show more</a>
+        <a class="js-expand explainer__read-more" data-link-name="{{=it.trackingCode.more}}">... Show more</a>
     </div>
     <div class="js-all-content explainer__content u-hidden">
         {{=it.data.allContent}}
-        <a class="js-collapse explainer__read-more" data-link-name="{{=it.trackingCode.less}}" href="#">Show less</a>
+        <a class="js-collapse explainer__read-more" data-link-name="{{=it.trackingCode.less}}">Show less</a>
     </div>
     <div class="js-all-content u-hidden explainer__feedback">
         {{#def.feedback}}


### PR DESCRIPTION
Currently, clicking the "show more" and "show less" links in the iOS app redirects the user to the interactive URL. I believe this is due to the links containing a URL fragment (AKA "hash reference") in the `href` attribute. Clicking the link from within an iframe opens the interactive document. This behaviour does not occur in web browsers.

Unfortunately I have been unable to replicate this issue in development, so I cannot confirm whether removing the `href` attribute this fixes the issue.

@joelochlann 
