### PR TITLE
Only cache main html file for 60 seconds

### DIFF
--- a/deploy.json
+++ b/deploy.json
@@ -10,14 +10,15 @@
                 "pathPrefixResource": "s3-path-prefix",
                 "bucket": "gdn-cdn",
                 "cacheControl": [
-                {
-                    "pattern": "^\\d+/",
-                    "value": "max-age=315360000"
-                },
-                {
-                    "pattern": ".*",
-                    "value": "max-age=60"
-                }]
+                    {
+                        "pattern": "embed\\.html",
+                        "value": "max-age=60"
+                    },
+                    {
+                        "pattern": ".*",
+                        "value": "max-age=315360000"
+                    }
+                ]
             }
         }
     },


### PR DESCRIPTION
Fixes a mistake in #43 where the pattern that was supposed to match only assets to set a far-future cache expiry on them actually matched everything in prod, causing the main page to have a far-future expire, preventing us from moving users forward onto the latest version.

It seems like someone expected the pattern would only be matching the portion of the URL after `brexit-companion`, e.g.

https://interactive.guim.co.uk/testing/2016/05/brexit-companion/1466165337781/embed.js
would be
`1466165337781/embed.js`

https://interactive.guim.co.uk/testing/2016/05/brexit-companion/embed/embed.html?id=conservatives_brexit
would be 
`embed/embed.html?id=conservatives_brexit`

In actual fact it seems to be matching from immediately after https://interactive.guim.co.uk/, so for a TEST URL

https://interactive.guim.co.uk/testing/2016/05/brexit-companion/embed/embed.html?id=conservatives_brexit
is 
`testing/2016/05/brexit-companion/embed/embed.html?id=conservatives_brexit`

while for a PROD URL:

https://interactive.guim.co.uk/2016/05/brexit-companion/embed/embed.html?id=conservatives_brexit
is 
`2016/05/brexit-companion/embed/embed.html?id=conservatives_brexit`

So everything in PROD gets `max-age=315360000` while everything in TEST gets `max-age=60`. Whoops!

@SiAdcock @philwills @rtyley 
