### PR TITLE
Move some functions out of .init()

### DIFF
--- a/src/js/embed.js
+++ b/src/js/embed.js
@@ -26,6 +26,70 @@ function getQueryParams() {
     return params;
 }
 
+function getRowById(rows, rowId) {
+    const row = rows.reduce((prev, currentRow) => {
+        if (currentRow.id.trim() === rowId) {
+            return currentRow;
+        }
+
+        return prev;
+    }, null);
+
+    if (!row) {
+        throw new Error(`row with id ${rowId} not found`);
+    }
+
+    return row;
+}
+
+function buildTemplateData(rowData, trackingCode) {
+    return {
+        data: rowData,
+        trackingCode: {
+            like: `${trackingCode}__like`,
+            dislike: `${trackingCode}__dislike`,
+            more: `${trackingCode}__more`,
+            less: `${trackingCode}__less`,
+            prev: `${trackingCode}__prev`,
+            next: `${trackingCode}__next`,
+            goTo: `${trackingCode}__go_to`,
+            back: `${trackingCode}__back`,
+            catchMeUp: `${trackingCode}__catch_me_up`,
+        },
+    };
+}
+
+function getRows(response) {
+    const rows = response.sheets.content;
+
+    if (!rows || !rows.length) {
+        throw new Error(`bad JSON response: ${JSON.stringify(response)}`);
+    }
+
+    return rows;
+}
+
+function getFormat(row) {
+    const format = formats[row.format];
+
+    if (!format) {
+        throw new Error(`format ${row.format} is not valid`);
+    }
+
+    return format;
+}
+
+function doRender(row, trackingCode, parentEl) {
+    const format = getFormat(row);
+    const { template, postRender, preprocess } = format;
+    const templateFn = dot.template(template, null, { feedback });
+    const rowData = preprocess(row);
+    const templateData = buildTemplateData(rowData, trackingCode);
+
+    render(templateFn, templateData, parentEl);
+    postRender(rowData);
+}
+
 
 window.init = function init(parentEl) {
     const params = getQueryParams();
@@ -34,70 +98,6 @@ window.init = function init(parentEl) {
     const defaultAtomId = params[defaultLevel] || params.id;
 
     iframeMessenger.enableAutoResize();
-
-    function getRowById(rows, rowId) {
-        const row = rows.reduce((prev, currentRow) => {
-            if (currentRow.id.trim() === rowId) {
-                return currentRow;
-            }
-
-            return prev;
-        }, null);
-
-        if (!row) {
-            throw new Error(`row with id ${rowId} not found`);
-        }
-
-        return row;
-    }
-
-    function buildTemplateData(rowData, trackingCode) {
-        return {
-            data: rowData,
-            trackingCode: {
-                like: `${trackingCode}__like`,
-                dislike: `${trackingCode}__dislike`,
-                more: `${trackingCode}__more`,
-                less: `${trackingCode}__less`,
-                prev: `${trackingCode}__prev`,
-                next: `${trackingCode}__next`,
-                goTo: `${trackingCode}__go_to`,
-                back: `${trackingCode}__back`,
-                catchMeUp: `${trackingCode}__catch_me_up`,
-            },
-        };
-    }
-
-    function getRows(response) {
-        const rows = response.sheets.content;
-
-        if (!rows || !rows.length) {
-            throw new Error(`bad JSON response: ${JSON.stringify(response)}`);
-        }
-
-        return rows;
-    }
-
-    function getFormat(row) {
-        const format = formats[row.format];
-
-        if (!format) {
-            throw new Error(`format ${row.format} is not valid`);
-        }
-
-        return format;
-    }
-
-    function doRender(row, trackingCode) {
-        const format = getFormat(row);
-        const { template, postRender, preprocess } = format;
-        const templateFn = dot.template(template, null, { feedback });
-        const rowData = preprocess(row);
-        const templateData = buildTemplateData(rowData, trackingCode);
-
-        render(templateFn, templateData, parentEl);
-        postRender(rowData);
-    }
 
     function renderTailoredAtom(err, responses) {
         if (err) {
@@ -111,7 +111,7 @@ window.init = function init(parentEl) {
         const row = getRowById(rows, id);
         const trackingCode = `brexit__${level}__${id}__tailored`;
 
-        doRender(row, trackingCode);
+        doRender(row, trackingCode, parentEl);
     }
 
     function renderUntailoredAtom(err, responses) {
@@ -124,7 +124,7 @@ window.init = function init(parentEl) {
         const row = getRowById(rows, id);
         const trackingCode = `brexit__${row.level}__${id}__untailored`;
 
-        doRender(row, trackingCode);
+        doRender(row, trackingCode, parentEl);
     }
 
     parallel(


### PR DESCRIPTION
Moves those functions which don't depend on closure-scope variables from `.init()` outside of `.init()`.

Not sure how much value this actually adds. In my mind it does make it a bit easier to see at a glance what `.init()` is doing without having to wade through loads of function definitions.

@SiAdcock 
