### PR TITLE
Move margin from slider to two sided module

### DIFF
--- a/src/css/modules/_slider.scss
+++ b/src/css/modules/_slider.scss
@@ -23,7 +23,6 @@
 .explainer__slider__item {
     flex-grow: 1;
     flex-basis: 0;
-    margin: 0 $explainer-control-button-size*0.5;
     padding: 6px 21px;
     background-color: colour(news-main-1);
 

--- a/src/css/modules/_twoSided.scss
+++ b/src/css/modules/_twoSided.scss
@@ -4,6 +4,9 @@ $two-sided-button-size: 34px;
     display: flex;
     flex-direction: column;
 }
+.explainer__two-sided__item {
+    margin: 0 $explainer-control-button-size*0.5;
+}
 .explainer__two-sided__row {
     flex-grow: 1;
     flex-shrink: 1;

--- a/src/js/text/twoSided.dot.html
+++ b/src/js/text/twoSided.dot.html
@@ -1,7 +1,7 @@
 <div class="explainer explainer--slider">
     <div class="explainer__slider-wrapper">
         <div class="explainer__slider js-slider">
-            <div class="explainer__content explainer__slider__item">
+            <div class="explainer__content explainer__slider__item explainer__two-sided__item">
                 <h1 class="explainer__header">
                     {{=it.data.answer1Title}}
                 </h1>
@@ -12,7 +12,7 @@
                     {{#def.feedback}}
                 </div>
             </div>
-            <div class="explainer__content explainer__slider__item explainer__two-sided">
+            <div class="explainer__content explainer__slider__item explainer__two-sided explainer__two-sided__item">
                 <div class="explainer__two-sided__row explainer__two-sided__top">
                     <a data-answer="one"
                        data-link-name="{{=it.trackingCode.goTo}}_answer_one"
@@ -37,7 +37,7 @@
                     </a>
                 </div>
             </div>
-            <div class="explainer__content explainer__slider__item">
+            <div class="explainer__content explainer__slider__item explainer__two-sided__item">
                 <h1 class="explainer__header">
                     {{=it.data.answer2Title}}
                 </h1>


### PR DESCRIPTION
14px margin on the `explainer__slider__item` class was causing the carousel to stretch beyond 100% of the viewport width on iOS.

![picture 25](https://cloud.githubusercontent.com/assets/5931528/16228113/efb782a0-37ac-11e6-8500-213ca98fe4df.png)

This margin is still necessary for the two-sided atom, so I have extracted the margin from `explainer__slider__item` to `explainer__two-sided__item`

![picture 26](https://cloud.githubusercontent.com/assets/5931528/16228239/c066dfd6-37ad-11e6-8ddb-a7673dd4913a.png)
