### PR TITLE
Update Prout checkpoint path to deal with cachebust

### DIFF
--- a/.prout.json
+++ b/.prout.json
@@ -1,11 +1,11 @@
 {
     "checkpoints": {
         "PROD": {
-            "url": "https://interactive.guim.co.uk/2016/05/brexit-companion/embed/embed.html",
+            "url": "https://interactive.guim.co.uk/2016/06/brexit-companion/embed/embed.html",
             "overdue": "3H"
         },
         "TEST": {
-            "url": "https://interactive.guim.co.uk/testing/2016/05/brexit-companion/embed/embed.html",
+            "url": "https://interactive.guim.co.uk/testing/2016/06/brexit-companion/embed/embed.html",
             "overdue": "4M"
         }
     }


### PR DESCRIPTION
Following on from https://github.com/guardian/interactive-brexit-companion/pull/58 which changed the location of the interactive to cachebust the immortal embed.html :crying_cat_face: 

cc @SiAdcock 
