### PR TITLE
Make feedback section look OK at small widths

### DIFF
--- a/src/css/modules/_feedback.scss
+++ b/src/css/modules/_feedback.scss
@@ -23,7 +23,6 @@
     }
 }
 .explainer__button--dislike {
-    margin-left: 3px;
     svg {
         transform: rotate(180deg);
     }
@@ -39,8 +38,18 @@
     @include fs-textSans(2);
     margin-top: $baseline;
     text-align: right;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+
+    .explainer--nav-controls & {
+        padding: 0 20px;
+    }
+}
+.explainer__feedback-buttons {
+    flex: 0 0 auto;
 }
 .explainer__feedback-question,
 .explainer__feedback-answer {
-    padding-right: $gutter / 2;
+    padding-right: $gutter;
 }

--- a/src/js/lib/shims.js
+++ b/src/js/lib/shims.js
@@ -1,7 +1,39 @@
-if (!('remove' in Element.prototype)) {
+/* eslint-disable */
+
+if (typeof Element.prototype.remove !== 'function') {
     Element.prototype.remove = function remove() {
         if (this.parentNode) {
             this.parentNode.removeChild(this);
         }
+    };
+}
+
+// element-closest | CC0-1.0 | github.com/jonathantneal/closest
+if (typeof Element.prototype.matches !== 'function') {
+    Element.prototype.matches = Element.prototype.msMatchesSelector || Element.prototype.mozMatchesSelector || Element.prototype.webkitMatchesSelector || function matches(selector) {
+        var element = this;
+        var elements = (element.document || element.ownerDocument).querySelectorAll(selector);
+        var index = 0;
+
+        while (elements[index] && elements[index] !== element) {
+            ++index;
+        }
+
+        return Boolean(elements[index]);
+    };
+}
+if (typeof Element.prototype.closest !== 'function') {
+    Element.prototype.closest = function closest(selector) {
+        var element = this;
+
+        while (element && element.nodeType === 1) {
+            if (element.matches(selector)) {
+                return element;
+            }
+
+            element = element.parentNode;
+        }
+
+        return null;
     };
 }

--- a/src/js/render.js
+++ b/src/js/render.js
@@ -4,7 +4,7 @@ import q from './lib/query';
 function bindEventHandlers() {
     q('.js-feedback').forEach(el => el.addEventListener('click', ev => {
         const feedbackButton = ev.currentTarget;
-        const feedback = feedbackButton.parentNode;
+        const feedback = feedbackButton.closest('.js-feedback-container');
         const surveyHref = feedbackButton.getAttribute('data-survey-href');
 
         feedback.innerHTML = thankYouHTML.replace(/%surveyHref%/g, surveyHref);

--- a/src/js/text/carousel.dot.html
+++ b/src/js/text/carousel.dot.html
@@ -33,7 +33,7 @@
         </a>
         {{~}}
     </div>
-    <div class="explainer__content explainer__feedback">
+    <div class="explainer__feedback js-feedback-container">
         {{#def.feedback}}
     </div>
 </div>

--- a/src/js/text/expandable.dot.html
+++ b/src/js/text/expandable.dot.html
@@ -10,7 +10,7 @@
         {{=it.data.allContent}}
         <a class="js-collapse explainer__read-more" data-link-name="{{=it.trackingCode.less}}">Show less</a>
     </div>
-    <div class="js-all-content u-hidden explainer__feedback">
+    <div class="js-all-content u-hidden explainer__feedback js-feedback-container">
         {{#def.feedback}}
     </div>
 </div>

--- a/src/js/text/feedback.dot.partial.html
+++ b/src/js/text/feedback.dot.partial.html
@@ -1,15 +1,17 @@
-<span class="explainer__feedback-question">Was this explainer helpful?</span>
-<button class="explainer__button js-feedback" data-survey-href="{{=it.data.survey_like}}"
-        data-link-name="{{=it.trackingCode.like}}">
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40">
-        <path fill="#FFF"
-              d="M33.78 22.437l-4.228 13.98L27.93 37.5 5.062 34.14V15.503l7.8-1.517L24.354 2.5h1.624L28.9 5.426l-4.548 8.67h.107l10.477 1.31"/>
-    </svg>
-</button>
-<button class="explainer__button explainer__button--dislike js-feedback"
-        data-survey-href="{{=it.data.survey_dislike}}" data-link-name="{{=it.trackingCode.dislike}}">
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40">
-        <path fill="#FFF"
-              d="M33.78 22.437l-4.228 13.98L27.93 37.5 5.062 34.14V15.503l7.8-1.517L24.354 2.5h1.624L28.9 5.426l-4.548 8.67h.107l10.477 1.31"/>
-    </svg>
-</button>
+<div class="explainer__feedback-question">Was this explainer helpful?</div>
+<div class="explainer__feedback-buttons">
+    <button class="explainer__button js-feedback" data-survey-href="{{=it.data.survey_like}}"
+            data-link-name="{{=it.trackingCode.like}}">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40">
+            <path fill="#FFF"
+                  d="M33.78 22.437l-4.228 13.98L27.93 37.5 5.062 34.14V15.503l7.8-1.517L24.354 2.5h1.624L28.9 5.426l-4.548 8.67h.107l10.477 1.31"/>
+        </svg>
+    </button>
+    <button class="explainer__button explainer__button--dislike js-feedback"
+            data-survey-href="{{=it.data.survey_dislike}}" data-link-name="{{=it.trackingCode.dislike}}">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40">
+            <path fill="#FFF"
+                  d="M33.78 22.437l-4.228 13.98L27.93 37.5 5.062 34.14V15.503l7.8-1.517L24.354 2.5h1.624L28.9 5.426l-4.548 8.67h.107l10.477 1.31"/>
+        </svg>
+    </button>
+</div>

--- a/src/js/text/flat.dot.html
+++ b/src/js/text/flat.dot.html
@@ -5,7 +5,7 @@
     <p>
         {{=it.data.content}}
     </p>
-    <div class="explainer__feedback">
+    <div class="explainer__feedback js-feedback-container">
         {{#def.feedback}}
     </div>
 </div>

--- a/src/js/text/thankYou.html
+++ b/src/js/text/thankYou.html
@@ -1,4 +1,8 @@
-<span class="explainer__feedback-answer">Thank you. Please tell us why in <a href="%surveyHref%" target="_blank">this survey!</a></span>
-<a class="explainer__button explainer__button--survey" href="%surveyHref%" target="_blank">
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30"><path d="M22.8 14.6L15.2 7l-.7.7 5.5 6.6H6v1.5h14l-5.5 6.6.7.7 7.6-7.6v-.9"></path></svg>
-</a>
+<div class="explainer__feedback-answer">
+	Thank you. Please tell us why in <a href="%surveyHref%" target="_blank">this&nbsp;survey!</a>
+</div>
+<div class="explainer__feedback-buttons">
+	<a class="explainer__button explainer__button--survey" href="%surveyHref%" target="_blank">
+	    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30"><path d="M22.8 14.6L15.2 7l-.7.7 5.5 6.6H6v1.5h14l-5.5 6.6.7.7 7.6-7.6v-.9"></path></svg>
+	</a>
+</div>

--- a/src/js/text/twoSided.dot.html
+++ b/src/js/text/twoSided.dot.html
@@ -1,14 +1,16 @@
 <div class="explainer explainer--slider">
     <div class="explainer__slider-wrapper">
         <div class="explainer__slider js-slider">
-            <div class="explainer__content explainer__slider__item explainer__two-sided__item">
-                <h1 class="explainer__header">
-                    {{=it.data.answer1Title}}
-                </h1>
-                <p>
-                    {{=it.data.answer1Body}}
-                </p>
-                <div class="explainer__feedback">
+            <div class="explainer__slider__item explainer__two-sided__item">
+                <div class="explainer__content">
+                    <h1 class="explainer__header">
+                        {{=it.data.answer1Title}}
+                    </h1>
+                    <p>
+                        {{=it.data.answer1Body}}
+                    </p>
+                </div>
+                <div class="explainer__feedback js-feedback-container">
                     {{#def.feedback}}
                 </div>
             </div>
@@ -37,14 +39,16 @@
                     </a>
                 </div>
             </div>
-            <div class="explainer__content explainer__slider__item explainer__two-sided__item">
-                <h1 class="explainer__header">
-                    {{=it.data.answer2Title}}
-                </h1>
-                <p>
-                    {{=it.data.answer2Body}}
-                </p>
-                <div class="explainer__feedback">
+            <div class="explainer__slider__item explainer__two-sided__item">
+                <div class="explainer__content">
+                    <h1 class="explainer__header">
+                        {{=it.data.answer2Title}}
+                    </h1>
+                    <p>
+                        {{=it.data.answer2Body}}
+                    </p>
+                </div>
+                <div class="explainer__feedback js-feedback-container">
                     {{#def.feedback}}
                 </div>
             </div>


### PR DESCRIPTION
Before we had some buttons wrapping in an ugly way at small widths. We also had bold text by mistake on the feedback text, because of the `.explainer__content` class (which didn't help with the wrapping problem).

I've added some flexbox wrappers so the feedback stuff looks good even at very narrow widths. I've also reduced the padding for the feedback on two-sided and carousel atoms so that hopefully it should actually fit on one line, even in the app (but again, thanks to flexbox, even if it does wrap it will look OK)
#### Before

![picture 232](https://cloud.githubusercontent.com/assets/5122968/16275523/3eb6f5ca-38a2-11e6-8b51-e3df836acac2.png)
![picture 231](https://cloud.githubusercontent.com/assets/5122968/16275524/3eb90e6e-38a2-11e6-9eee-101e443f5258.png)
#### After

![picture 228](https://cloud.githubusercontent.com/assets/5122968/16275541/59701d92-38a2-11e6-97b7-ca2997a74b76.png)
![picture 227](https://cloud.githubusercontent.com/assets/5122968/16275540/597006cc-38a2-11e6-8482-e132f7b0e513.png)

@SiAdcock 
