### PR TITLE
Use full id for componenet name sent to ophan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ bower_components
 build
 deploy
 cfg/aws-keys.json
+.idea/

--- a/src/js/embed.js
+++ b/src/js/embed.js
@@ -90,7 +90,7 @@ window.init = function init(parentEl) {
     const params = getQueryParams();
     const defaultLevel = params.default || 'intermediate';
     const defaultAtomId = params.id;
-    const atomName = `explainer_feedback__${defaultAtomId.substring(0, 8)}`;
+    const atomName = `explainer_feedback__${defaultAtomId}`;
 
     iframeMessenger.enableAutoResize();
 


### PR DESCRIPTION
This will allow ophan to look up an explainer in capi without talking to explain-maker.
