### PR TITLE
Open urls in parent page

### DIFF
--- a/src/css/modules/_explainer.scss
+++ b/src/css/modules/_explainer.scss
@@ -13,5 +13,5 @@
 .explainer__content {
     @include fs-textSans(3);
     margin: 0 0 $baseline/2 0;
-    font-weight: bold;
+    font-weight: 400;
 }

--- a/src/embed.html
+++ b/src/embed.html
@@ -5,6 +5,7 @@
     <meta gitCommitId="<%= gitCommitId %>" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="stylesheet" type="text/css" href="../<%= assetPath %>/embed.css" />
+    <base target="_parent" />
 </head>
 <body>
     <div class="interactive-embed js-interactive"></div>


### PR DESCRIPTION
Links aren't normally allowed in text atoms, but someone's managed to copy some in here: https://www.theguardian.com/world/2016/oct/17/thai-woman-accused-of-insulting-late-king-bhumibol-adulyadej-forced-to-kneel-koh-samui

At the moment, the links open inside the explainer iframe which is a bit sad. This change makes them open in the parent. 

You can see an example page here with this version at the top and the existing version at the bottom: https://viewer.code.dev-gutools.co.uk/preview/film/2016/oct/17/la-la-test-one-two-three#

This PR also contains a styling change which is actually already on PROD but sadly hasn't been merged into this branch yet. 
